### PR TITLE
added new junction wandering system that should work identical to rct

### DIFF
--- a/micro_rct/path.py
+++ b/micro_rct/path.py
@@ -158,8 +158,24 @@ class Path:
                 connections += 1
         if connections > 2:
             self.junction = True
+        # elif connections == 1:
+        #     if (self.links[0] and self.links[1]) or (self.links[1] and self.links[2]) or (self.links[2] and self.links[3]) or (self.links[3] and self.links[1]):
+        #         self.junction = True
         else:
             self.junction = False
+    
+    def get_junctions(self):
+        junctions = []
+        for i, link in enumerate(self.links):
+            if link and not link.junction:
+                # go off in this direction until there is another junction
+                next_link = link.links[i]
+                while next_link and next_link.links[i] and not next_link.junction:
+                    next_link = next_link.links[i]
+                link = next_link
+            if link:
+                junctions.append(link)
+        return junctions
 
     def get_adjacent(self, direction):
         adj_pos = (self.position[0] + direction[0],

--- a/micro_rct/peep.py
+++ b/micro_rct/peep.py
@@ -384,9 +384,9 @@ class Peep:
 
     def wander(self):
         '''Pick a random destination.'''
-        traversible_tiles = [tile for tile in self.park.path_net.items() if tile[1].junction]            
-    #   print('traversible tiles: {}'.format(traversible_tiles))
-        goal = random.choice(list(traversible_tiles))
+        current_tile = self.park.path_net[self.position]
+        traversible_tiles = current_tile.get_junctions()
+        goal = random.choice(traversible_tiles)
         #FIXME: do not create new path object every time
-        self.headingTo = self.park.path_net[goal[0]]
+        self.headingTo = self.park.path_net[goal.position]
 


### PR DESCRIPTION
Does simple greedy 2d flood fill to find the nearest junctions for a peep who is wandering. Peep will then proceed to go to that junction. 

In the future, we can modify what consists of a junction, like a path with park benches or a simple corner. Even ride entrances count as junctions in the original RCT code according to the docs.