### PR TITLE
New metrics in RCT.update_terminal_metrics()

### DIFF
--- a/micro_rct/attraction.py
+++ b/micro_rct/attraction.py
@@ -6,7 +6,8 @@ class Path:
 
 class Attraction:
     def __init__(self, name, thirst, hunger, toilet, excitement, intensity, nausea, time, cost, price, size_x, size_y,
-            mark, position_x=0, position_y=0):
+            mark, ride_i, position_x=0, position_y=0):
+        self.ride_i = ride_i
         self.name = name
         self.mark = mark
         if thirst!=0 or hunger!=0 or toilet!=0 or name == 'FirstAid' or name =='InformationKiosk' or name=='Shop':

--- a/micro_rct/gym_envs/rct_env.py
+++ b/micro_rct/gym_envs/rct_env.py
@@ -8,6 +8,7 @@ import gym
 import numpy as np
 #import torch
 import yaml
+from skbio.diversity.alpha import shannon
 from gym import core
 from micro_rct import map_utility
 from micro_rct.map_utility import placePath, placeRide
@@ -193,6 +194,14 @@ class RCT(core.Env):
 
     def demolish_tile(self, x, y):
         return map_utility.try_demolish_tile(self.rct_env.park, x, y)
+
+    def update_terminal_metrics(self):
+        self.net_vomits = self.rct_env.park.net_vomits
+        self.avg_ride_nausea =     np.mean([ride.nausea     for ride in self.rct_env.park.rides_by_pos.values()])
+        self.avg_ride_excitement = np.mean([ride.excitement for ride in self.rct_env.park.rides_by_pos.values()])
+        self.avg_ride_intensity =  np.mean([ride.intensity  for ride in self.rct_env.park.rides_by_pos.values()])
+        ride_type_counts = np.bincount([ride.ride_i for ride in self.rct_env.park.rides_by_pos.values()])
+        self.ride_diversity = shannon(ride_type_counts)
 
     def update_metrics(self):
         self.metrics = {

--- a/micro_rct/park.py
+++ b/micro_rct/park.py
@@ -68,6 +68,7 @@ class Park():
         self.money = Park.INIT_MONEY
         self.last_money = self.money
         self.income = 0
+        self.net_vomits = 0
 
     def clone(self, settings):
         new_park = Park(settings)
@@ -109,6 +110,7 @@ class Park():
         path_tile = self.path_net[x, y]
         path_tile.vom_time = PARK.VOMIT_LIFESPAN
         self.vomit_paths[x, y] = path_tile
+        self.net_vomits += 1
 
     def populate_path_net(self):
         '''

--- a/micro_rct/rct_test_objects.py
+++ b/micro_rct/rct_test_objects.py
@@ -21,10 +21,11 @@ with open(obj_list_path, 'r') as fp:
             if line and line[0] != "#":
                 arr = line.replace("\t", "").split(",")
                 symbol = arr[-1]
-                arr = arr[:1]+[int(arr[i]) for i in range(1,len(arr)-1)]+arr[-1:] + [i]
+                arr = arr[:1]+[int(arr[j]) for j in range(1,len(arr)-1)]+arr[-1:] + [i]
                 #newObj = RS.alt_init(arr)
                 object_list.append(create_attraction(arr))
                 symbol_list.append(symbol)
+                i += 1
     i = 0
     for symb in symbol_list:
         symbol_dict[symb[0]] = (i, object_list[i]().name)

--- a/rand_agent.py
+++ b/rand_agent.py
@@ -25,14 +25,12 @@ def main(settings):
         env.reset()
         env.render()
 
-        for j in range(100):
-            env.act(env.action_space.sample())
-            env.render()
-        for i in range(100):
+        for j in range(200):
+            env.step(env.action_space.sample())
             env.step_sim()
             env.render()
-
-        env.render()
+        env.update_terminal_metrics()
+        
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ colorama==0.4.4
 stable-baselines3
 pyparsing
 plotly==4.12.0
+scikit-bio==0.5.6


### PR DESCRIPTION
Add some metrics to be computed at the end of a simulation during, e.g., evolution (namely, avg. ride metrics, net vomits in the park, diversity as Shannon entropy of rides-by-type in the park).

You will need to call `env.update_terminal_metrics()` on the environment (where `env` is an RCT instance), and can then access `env.net_vomits, env.avg_ridenausea, env.avg_ride_intensity, env.avg_ride_excitement` and `env.ride_diversity`. I'm not updating them every step for the sake of saving compute time.

I'm using a built-in Shannon entropy function from scikit-bio for diversity. Its range of output is quite narrow. We may prefer some different metric in its place.