### PR TITLE
Add ride_cost toggle, and deletion_rate to config.

### DIFF
--- a/configs/settings.yml
+++ b/configs/settings.yml
@@ -1,5 +1,5 @@
 general:
-    render: False
+    render: True
     verbose: False
     render_screen_width: 500
     render_screen_height: 500
@@ -13,7 +13,9 @@ environment:
     n_actions: 10
     ride_range: [0, 4]
     fixed_path: True  # all ride placements along fixed square path
+    ride_cost: False  # whether or not rides cost money to build
     init_money: 15000  # how much money the park starts out with
+    deletion_rate: 2  # how many deletion actions (at present, there are 26 ride-placement actions -- one per ride type -- so "26" means 50/50 build/deletion rates)
 experiments:
     ticks: [500]
 evolution:

--- a/micro_rct/gym_envs/rct_env.py
+++ b/micro_rct/gym_envs/rct_env.py
@@ -115,7 +115,11 @@ class RCT(core.Env):
         high = np.zeros(act_shape)
         high[0] = self.MAP_WIDTH
         high[1] = self.MAP_HEIGHT
-        self.N_ACT_CHAN = len(ride_list) + 2  # build a ride, place path, or demolish
+        n_rides = len(ride_list)
+        self.N_ACT_CHAN = n_rides  # build a ride
+        if not self.FIXED_PATH:
+            self.N_ACT_CHAN += 1  # build a path
+        self.N_ACT_CHAN += settings['environment']['deletion_rate']  # delete, with a given frequency
         self.action_space = gym.spaces.MultiDiscrete(
                 (self.MAP_WIDTH, self.MAP_HEIGHT, self.N_ACT_CHAN, 4)
                 )

--- a/micro_rct/map_utility.py
+++ b/micro_rct/map_utility.py
@@ -152,7 +152,8 @@ def demolish_tile(park, x, y):
         # important to do this here, lest we recursively demolish entire ride patch repeatedly
         ride = park.rides_by_pos.pop(center)
         # Deleting a ride gives the park a full refund on the ride's original cost
-        park.money += ride.build_cost
+        if park.ride_cost:
+            park.money += ride.build_cost
         assert center == ride.position
 
         for ride_pos in ride.locs:
@@ -225,7 +226,8 @@ def _add_ride(park, _ride, x, y, ride_i, entrance):
             _ride.locs.append((i, j))
    #park.updateMap((x, y), size, mark, _ride.entrance)
     assert _ride.entrance in park.path_net
-    park.money -= _ride.build_cost
+    if park.ride_cost:
+        park.money -= _ride.build_cost
     assert park.money >= 0
     return _ride
 
@@ -252,7 +254,10 @@ def place_ride_tile(park, x, y, ride_i, rotation=0, destructive=True):
     else:
         raise Exception('invalid entrance position index')
 
-    build_budget = park.money - _ride.build_cost
+    if park.ride_cost:
+        build_budget = park.money - _ride.build_cost
+    else:
+        build_budget = None
     if checkCanPlaceOrNot(park, x, y, size[0], size[1], destructive=destructive, budget=build_budget):
         result = clear_for_placement(park, x, y, size[0], size[1])
 #       print('clear_for_placement result:', result)
@@ -297,7 +302,10 @@ def placeRide(park, ride_i, verbose=False):
 
         while startList and not placed:
             rand = startList.pop()
-            build_budget = park.money - _ride.build_cost
+            if park.ride_cost:
+                build_budget = park.money - _ride.build_cost
+            else:
+                build_budget = None
             placed = checkCanPlaceOrNot(park,rand[0],rand[1],size[0],size[1], destructive=True, budget=build_budget)
 
         if placed:

--- a/micro_rct/park.py
+++ b/micro_rct/park.py
@@ -65,6 +65,7 @@ class Park():
         self.avg_peep_happiness = 0
         self.path_net = {}
         self.vomit_paths = {}
+        self.ride_cost = settings['environment']['ride_cost']
         self.money = self.INIT_MONEY
         self.last_money = self.money
         self.income = 0


### PR DESCRIPTION
`ride_cost` will make ride placement "free" if switched off. `deletion_rate`
allows the user to specify the number of deletion actions in the
environment's action space, i.e. specify the probability of deletion
w.r.t. building. There are 26 ride-placement actions so `deletion_rate =
0` means no deletion ever, `2` is the default, and what we have been
using up until now (build:deletion ratio of 26:2) and `26` means equal
likelihood of building/deleting, etc.